### PR TITLE
Anti-ghosting Control Scheme

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -706,7 +706,7 @@ function playerMove(player) {
     right = Crafty.keys['RIGHT_ARROW'];
     up = Crafty.keys['UP_ARROW'];
     dig = Crafty.keys['DOWN_ARROW'];
-    fire = Crafty.keys['CTRL'];
+    fire = Crafty.keys['SPACE'];
     break;
   }
 


### PR DESCRIPTION
Please test this.

Bazooka aiming is persistent. Bazooka is displayed whenever you have it, and goes away when you don't. Hold the fire key to aim, and release to fire. If you hold down while releasing, it won't fire, so that's effectively a way to cancel. It is pretty tricky to do, though, and not super intuitive.

Player 2 moved to arrow keys with space key to fire. This shouldn't have any ghosting.
