### PR TITLE
Fluffy garbage collect

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1229,10 +1229,10 @@ function deathFromBelow() {
   }
   should_creep = false;
 
-/*  for (var n = 0; n < lava_list.length; n++) {
+  for (var n = 0; n < lava_list.length; n++) {
     var lava = lava_list[n];
     lava.tween({y: lava.y - BLOCK_SIZE}, 60);
-  } */
+  }
 }
 
 function startMusic() {


### PR DESCRIPTION
Forced some garbage collection. Made sure the lava_list gets reset on restart. Whoever wrote and pulled that code should've noticed the general trend of all of our big lists of objects =.=" I'm thinking of changing the lava code to fix our restart-ing performance bug without need for bigger sprites, but I don't yet know if that will actually work.
